### PR TITLE
Update OpenMP 4+ compatibility pull request for LAMMPS

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -248,11 +248,15 @@ if(BUILD_OMP)
     message(FATAL_ERROR "Cannot find the 'omp.h' header file required for full OpenMP support")
   endif()
 
-  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.99.9))
-    # GCC 9.x strictly implements OpenMP 4.0 semantics for consts.
-    add_definitions(-DLAMMPS_OMP_COMPAT=4)
+  if (((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.99.9)) OR
+      ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.99.9)) OR
+      ((CMAKE_CXX_COMPILER_ID STREQUAL "Intel") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 18.99.9))
+      )
+    # GCC 9.x and later plus Clang 10.x and later implement strict OpenMP 4.0 semantics for consts.
+    # Intel 18.0 was tested to support both, so we switch to OpenMP 4+ from 19.x onward to be safe.
+    target_compile_definitions(lammps PRIVATE -DLAMMPS_OMP_COMPAT=4)
   else()
-    add_definitions(-DLAMMPS_OMP_COMPAT=3)
+    target_compile_definitions(lammps PRIVATE -DLAMMPS_OMP_COMPAT=3)
   endif()
   target_link_libraries(lammps PRIVATE OpenMP::OpenMP_CXX)
 endif()

--- a/doc/src/Build_basics.rst
+++ b/doc/src/Build_basics.rst
@@ -142,13 +142,15 @@ please refer to its documentation.
 **OpenMP Compiler compatibility info**\ :
 
 Some compilers do not fully support the ``default(none)`` directive
-and others (e.g. GCC version 9 and beyond) may implement OpenMP 4.0
-semantics, which are incompatible with the OpenMP 3.1 semantics used
-in LAMMPS (for maximal compatibility with compiler versions in use).
-LAMMPS will try to detect compilers that use OpenMP 4.0 semantics and
-change the directives accordingly, but if your compiler is not
-detected, you may set the define ``-D LAMMPS_OMP_COMPAT=4`` in ``LMP_INC``
-or the CMake build command.
+and others (e.g. GCC version 9 and beyond, Clang version 10 and later)
+may implement strict OpenMP 4.0 and later semantics, which are incompatible
+with the OpenMP 3.1 semantics used in LAMMPS for maximal compatibility
+with compiler versions in use.  If compilation with OpenMP enabled fails
+because of your compiler requiring strict OpenMP 4.0 semantic, you can
+change the behvior by adding ``-D LAMMPS_OMP_COMPAT=4`` to the ``LMP_INC``
+variable in your makefile, or add it to the command line while configuring
+with CMake. CMake will autodetect the suitable setting for the GNU, Clang,
+and Intel compilers.
 
 ----------
 

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -1203,7 +1203,8 @@ char *Info::get_compiler_info()
 #if __clang__
   snprintf(buf,_INFOBUF_SIZE,"Clang C++ %s", __VERSION__);
 #elif __INTEL_COMPILER
-  snprintf(buf,_INFOBUF_SIZE,"Intel C++ %s", __VERSION__);
+  double version = static_cast<double>(__INTEL_COMPILER)*0.01;
+  snprintf(buf,_INFOBUF_SIZE,"Intel C++ %5.2f.%d / %s", version, __INTEL_COMPILER_UPDATE, __VERSION__);
 #elif __GNUC__
   snprintf(buf,_INFOBUF_SIZE,"GNU C++ %s",   __VERSION__);
 #else

--- a/src/omp_compat.h
+++ b/src/omp_compat.h
@@ -23,8 +23,8 @@
 //
 // To date, most compilers still accept the OpenMP 3.0 form,
 // so this is what LAMMPS primarily uses.  For those compilers
-// that strictly implement OpenMP 4.0 (such as GCC 9.0), we
-// give up default(none).
+// that strictly implement OpenMP 4.0 (such as GCC 9.0 and later
+// or Clang 10.0 and later), we give up default(none).
 #if LAMMPS_OMP_COMPAT == 4
 #    define LMP_SHARED(...)
 #    define LMP_DEFAULT_NONE default(shared)


### PR DESCRIPTION
## Purpose

This pull request updates pull request lammps#1651
It updates the cmake script code to be aligned with recent refactoring in master.
It triggers in `cmake/CMakeLists.txt` the switch to OpenMP4+ also for Clang 10+ (required) and Intel 19+ (not strictly required, but 18.0.3 has been tested to work with both)
It updates and corrects the documentation related to this issue.

## Author(s)

Axel Kohlmeyer (Temple U)
